### PR TITLE
Troca símbolos latex e em notação C-like de operadores relacionais para unicode em blocos de código

### DIFF
--- a/projeto/etapa5.org
+++ b/projeto/etapa5.org
@@ -437,11 +437,11 @@ previamente (pode-se saltar para um código mais a frente do programa).
 
 #+BEGIN_EXAMPLE
 cmp_LT r1, r2 -> r3        // r3 = true se r1 < r2, senão r3 = false
-cmp_LE r1, r2 -> r3        // r3 = true se r1 <= r2, senão r3 = false
+cmp_LE r1, r2 -> r3        // r3 = true se r1 ≤ r2, senão r3 = false
 cmp_EQ r1, r2 -> r3        // r3 = true se r1 = r2, senão r3 = false
-cmp_GE r1, r2 -> r3        // r3 = true se r1 >= r2, senão r3 = false
+cmp_GE r1, r2 -> r3        // r3 = true se r1 ≥ r2, senão r3 = false
 cmp_GT r1, r2 -> r3        // r3 = true se r1 > r2, senão r3 = false
-cmp_NE r1, r2 -> r3        // r3 = true se r1 != r2, senão r3 = false
+cmp_NE r1, r2 -> r3        // r3 = true se r1 ≠ r2, senão r3 = false
 cbr     r1    -> l2, l3    // PC = endereço(l2) se r1 = true, senão PC = endereço(l3)
 #+END_EXAMPLE
 

--- a/projeto/etapa5.org
+++ b/projeto/etapa5.org
@@ -510,11 +510,11 @@ jumpI          ->  l1        // PC = endereço(l1)
 jump           ->  r1        // PC = r1
 cbr    r1      ->  l2, l3    // PC = endereço(l2) se r1 = true, senão PC = endereço(l3)
 cmp_LT r1, r2  ->  r3        // r3 = true se r1 < r2, senão r3 = false
-cmp_LE r1, r2  ->  r3        // r3 = true se r1 \leq r2, senão r3 = false
+cmp_LE r1, r2  ->  r3        // r3 = true se r1 ≤ r2, senão r3 = false
 cmp_EQ r1, r2  ->  r3        // r3 = true se r1 = r2, senão r3 = false
-cmp_GE r1, r2  ->  r3        // r3 = true se r1 \geq r2, senão r3 = false
+cmp_GE r1, r2  ->  r3        // r3 = true se r1 ≥ r2, senão r3 = false
 cmp_GT r1, r2  ->  r3        // r3 = true se r1 > r2, senão r3 = false
-cmp_NE r1, r2  ->  r3        // r3 = true se r1 \ne r2, senão r3 = false
+cmp_NE r1, r2  ->  r3        // r3 = true se r1 ≠ r2, senão r3 = false
 #+END_EXAMPLE
 
 * Anexo - Simulador ILOC (=ilocsim=)


### PR DESCRIPTION
Na descrição da Etapa 5 do projeto de compilador, na seção "Sumários de Operações ILOC de Fluxo de Controle", um bloco de código ILOC contém comentários com símbolos especiais, na notação LaTeX: \leq, \geq e \ne. Esses símbolos não são renderizados apropriadamente, por estarem dentro de um bloco de código (#+BEGIN_EXAMPLE e #+END_EXAMPLE).

Eu proponho trocar esses símbolos em notação LaTeX para seus caracteres unicode equivalentes. Além disso, em outro bloco de código ILOC se faz referência a operadores relacionais, porém com uma notação "C-like", ou seja, com o uso de dois caracteres ASCII: <=, <= e !=. Proponho também trocar a notação neste bloco de código para os caracteres unicode, para ficar mais homogêneo.